### PR TITLE
US890043: Added Java21 images and moved NodeJS18 to NodeJS20

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The images which are built in this project are:
   - opensuse-jdk11
   - opensuse-jre17
   - opensuse-jdk17
+  - opensuse-jre21
+  - opensuse-jdk21
   - opensuse-nodejs20
   - opensuse-python3
   - opensuse-dotnet6-aspnet

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The images which are built in this project are:
   - opensuse-jdk11
   - opensuse-jre17
   - opensuse-jdk17
-  - opensuse-nodejs18
+  - opensuse-nodejs20
   - opensuse-python3
   - opensuse-dotnet6-aspnet
   - opensuse-dotnet6-runtime

--- a/opensuse-java21-images/pom.xml
+++ b/opensuse-java21-images/pom.xml
@@ -26,11 +26,11 @@
         <artifactId>opensuse-base-images-aggregator</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
-    
-    <artifactId>opensuse-nodejs18-image</artifactId>
+
+    <artifactId>opensuse-java21-images</artifactId>
     <packaging>pom</packaging>
 
-    <name>openSUSE NodeJS18 image</name>
+    <name>openSUSE Java21 images</name>
 
     <build>
         <plugins>
@@ -56,9 +56,25 @@
                 <configuration>
                     <images>
                         <image>
-                            <name>${dockerCafImagePrefix}opensuse-nodejs18${dockerProjectVersion}</name>
+                            <name>${dockerCafImagePrefix}opensuse-jre21${dockerProjectVersion}</name>
                             <build>
                                 <contextDir>.</contextDir>
+                                <dockerFile>Dockerfile.jre</dockerFile>
+                                <args>
+                                    <!-- Enable internet access -->
+                                    <http_proxy>${env.HTTP_PROXY}</http_proxy>
+                                    <https_proxy>${env.HTTPS_PROXY}</https_proxy>
+                                    <no_proxy>${env.NO_PROXY}</no_proxy>
+                                    <!-- Pass in opensuse-base image as param -->
+                                    <BASE_IMAGE>${dockerCafImagePrefix}opensuse-base${dockerProjectVersion}</BASE_IMAGE>
+                                </args>
+                            </build>
+                        </image>
+                        <image>
+                            <name>${dockerCafImagePrefix}opensuse-jdk21${dockerProjectVersion}</name>
+                            <build>
+                                <contextDir>.</contextDir>
+                                <dockerFile>Dockerfile.jdk</dockerFile>
                                 <args>
                                     <!-- Enable internet access -->
                                     <http_proxy>${env.HTTP_PROXY}</http_proxy>

--- a/opensuse-java21-images/src/main/docker/Dockerfile.jdk
+++ b/opensuse-java21-images/src/main/docker/Dockerfile.jdk
@@ -1,0 +1,57 @@
+#
+# Copyright 2017-2024 Open Text.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Stage 1
+#
+ARG BASE_IMAGE
+FROM $BASE_IMAGE AS stage1
+
+# Refresh the OS repositories and install OpenJDK 17 Development Kit
+RUN zypper -n install java-21-openjdk-devel && \
+    zypper -n clean --all
+
+# Install Java certificate installation script
+ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-script/install-ca-cert-java.sh \
+    /startup/startup.d/
+RUN chmod +x /startup/startup.d/install-ca-cert-java.sh
+
+# Set Java Home
+ENV JAVA_HOME=/usr/lib64/jvm/java-21-openjdk-21
+
+# Set JRE Home
+ENV JRE_HOME=/usr/lib64/jvm/java-21-openjdk-21
+
+#
+# Stage 2: Create the NSS database
+#
+FROM stage1 AS stage2
+
+RUN zypper -n install mozilla-nss-tools
+
+RUN mkdir /etc/pki/nssdb
+RUN certutil -N --empty-password -d /etc/pki/nssdb/
+# The '/usr/lib64/jvm/java-21-openjdk-21/conf/security/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
+# See: https://docs.oracle.com/en/java/javase/21/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
+RUN chmod a+rw /etc/pki/nssdb/*
+
+#
+# Stage 3: The remainder of the actual image definition
+#
+FROM stage1
+
+# Copy nssdb
+COPY --from=stage2 /etc/pki/nssdb /etc/pki/nssdb

--- a/opensuse-java21-images/src/main/docker/Dockerfile.jdk
+++ b/opensuse-java21-images/src/main/docker/Dockerfile.jdk
@@ -20,7 +20,7 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE AS stage1
 
-# Refresh the OS repositories and install OpenJDK 17 Development Kit
+# Refresh the OS repositories and install OpenJDK 21 Development Kit
 RUN zypper -n install java-21-openjdk-devel && \
     zypper -n clean --all
 

--- a/opensuse-java21-images/src/main/docker/Dockerfile.jre
+++ b/opensuse-java21-images/src/main/docker/Dockerfile.jre
@@ -42,7 +42,7 @@ RUN zypper -n install mozilla-nss-tools
 RUN mkdir /etc/pki/nssdb
 RUN certutil -N --empty-password -d /etc/pki/nssdb/
 # The '/usr/lib64/jvm/java-21-openjdk-21/conf/security/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
-# See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
+# See: https://docs.oracle.com/en/java/javase/21/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
 RUN chmod a+rw /etc/pki/nssdb/*
 
 #

--- a/opensuse-java21-images/src/main/docker/Dockerfile.jre
+++ b/opensuse-java21-images/src/main/docker/Dockerfile.jre
@@ -1,0 +1,54 @@
+#
+# Copyright 2017-2024 Open Text.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Stage 1
+#
+ARG BASE_IMAGE
+FROM $BASE_IMAGE AS stage1
+
+# Refresh the OS repositories and install OpenJDK 21 Runtime Environment
+RUN zypper -n install java-21-openjdk && \
+    zypper -n clean --all
+
+# Install Java certificate installation script
+ADD https://raw.githubusercontent.com/CAFapi/caf-common/v1.19.0/container-cert-script/install-ca-cert-java.sh \
+    /startup/startup.d/
+RUN chmod +x /startup/startup.d/install-ca-cert-java.sh
+
+# Set JRE Home
+ENV JRE_HOME=/usr/lib64/jvm/java-21-openjdk-21
+
+#
+# Stage 2: Create the NSS database
+#
+FROM stage1 AS stage2
+
+RUN zypper -n install mozilla-nss-tools
+
+RUN mkdir /etc/pki/nssdb
+RUN certutil -N --empty-password -d /etc/pki/nssdb/
+# The '/usr/lib64/jvm/java-21-openjdk-21/conf/security/nss.fips.cfg' file contains'nssDbMode=readWrite', so adjust permissions accordingly to allow services running as a non-root user to access the NSS directory.
+# See: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html#GUID-85EA1017-E59C-49B9-9207-65B7B2BF171E__GUID-D7866EA0-8645-4F13-A702-7502BCDFC51F
+RUN chmod a+rw /etc/pki/nssdb/*
+
+#
+# Stage 3: The remainder of the actual image definition
+#
+FROM stage1
+
+# Copy nssdb
+COPY --from=stage2 /etc/pki/nssdb /etc/pki/nssdb

--- a/opensuse-nodejs20-image/pom.xml
+++ b/opensuse-nodejs20-image/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2024 Open Text.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.cafapi</groupId>
+        <artifactId>opensuse-base-images-aggregator</artifactId>
+        <version>4.1.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>opensuse-nodejs20-image</artifactId>
+    <packaging>pom</packaging>
+
+    <name>openSUSE NodeJS20 image</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>docker-push</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>push</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <images>
+                        <image>
+                            <name>${dockerCafImagePrefix}opensuse-nodejs20${dockerProjectVersion}</name>
+                            <build>
+                                <contextDir>.</contextDir>
+                                <args>
+                                    <!-- Enable internet access -->
+                                    <http_proxy>${env.HTTP_PROXY}</http_proxy>
+                                    <https_proxy>${env.HTTPS_PROXY}</https_proxy>
+                                    <no_proxy>${env.NO_PROXY}</no_proxy>
+                                    <!-- Pass in opensuse-base image as param -->
+                                    <BASE_IMAGE>${dockerCafImagePrefix}opensuse-base${dockerProjectVersion}</BASE_IMAGE>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                    <verbose>true</verbose>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/opensuse-nodejs20-image/src/main/docker/Dockerfile
+++ b/opensuse-nodejs20-image/src/main/docker/Dockerfile
@@ -18,5 +18,5 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 # Update the OS packages and install NodeJS
-RUN zypper -n install nodejs18 npm && \
+RUN zypper -n install nodejs20 npm && \
     zypper -n clean --all

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@
         <module>opensuse-java8-images</module>
         <module>opensuse-java11-images</module>
         <module>opensuse-java17-images</module>
-        <module>opensuse-nodejs18-image</module>
+        <module>opensuse-java21-images</module>
+        <module>opensuse-nodejs20-image</module>
         <module>opensuse-dotnet6-images</module>
         <module>opensuse-python3-image</module>
     </modules>

--- a/release-notes-4.1.0.md
+++ b/release-notes-4.1.0.md
@@ -4,5 +4,8 @@
 ${version-number}
 
 #### New Features
+- US890043: Images are now based on openSUSE Leap [15.6](https://get.opensuse.org/leap/15.6/)
+  - This repository now includes Java 21 images.
+  - NodeJS18 is no longer available on Leap 15.6 so it has been replaced with a NodeJS20 image.
 
 #### Known Issues


### PR DESCRIPTION
Ticket: https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=890043

Moved Java 21 images into this repository and changed NodeJS18 image to NodeJS20 image as nodejs18 is not available on Leap 15.6